### PR TITLE
Expanded service description regex so it passes tests

### DIFF
--- a/api/src/main/java/SpringProject/_Spring/dto/service/ServiceAtClinicRequestDTO.java
+++ b/api/src/main/java/SpringProject/_Spring/dto/service/ServiceAtClinicRequestDTO.java
@@ -13,7 +13,9 @@ public record ServiceAtClinicRequestDTO(
         @NotBlank
         @NotNull
         @Size(max = 255, message = "Description too long! Please limit it to a max of 255 characters!")
-        @Pattern(regexp = "^[A-Za-z0-9\\s-]+$", message = "Description must contain only letters, spaces, numbers and dashes!")
+        @Pattern(regexp = "^[A-Za-z0-9\\s.\\-?!',]*$",
+                message = "Description must contain only letters, spaces, numbers, fullstops," +
+                        " apostrophes, commas, exclamation and question marks and dashes!")
         String description,
 
         @NotNull

--- a/vet-spring/src/pages/services/ServiceAdd.jsx
+++ b/vet-spring/src/pages/services/ServiceAdd.jsx
@@ -84,7 +84,7 @@ export const ServiceAdd = ({ service }) => {
             <textarea
               {...register("description", {
                 required: "Description is required",
-                pattern: "^[A-Za-zs-]+$",
+                pattern: "^^[A-Za-z0-9\\s.\\-?!',]*$",
                 maxLength: 255,
               })}
               rows="8"

--- a/vet-spring/src/pages/services/ServiceAdd.jsx
+++ b/vet-spring/src/pages/services/ServiceAdd.jsx
@@ -84,7 +84,7 @@ export const ServiceAdd = ({ service }) => {
             <textarea
               {...register("description", {
                 required: "Description is required",
-                pattern: "^^[A-Za-z0-9\\s.\\-?!',]*$",
+                pattern: "^[A-Za-z0-9\\s.\\-?!',]*$",
                 maxLength: 255,
               })}
               rows="8"

--- a/vet-spring/src/pages/services/ServiceUpdate.jsx
+++ b/vet-spring/src/pages/services/ServiceUpdate.jsx
@@ -89,6 +89,7 @@ export const ServiceUpdate = () => {
             <textarea
               {...register("description", {
                 required: "Description is required",
+                pattern: "^[A-Za-z0-9\\s.\\-?!',]*$",
                 maxLength: 255,
               })}
               rows="8"


### PR DESCRIPTION
The regex now allows for fullstops, apostrophes, commas, exclamation marks and question marks