### PR TITLE
KOM-136_alt2 ; THIRD ATTEMPT: Implementing pawss images to all Pages using App.jsx

### DIFF
--- a/api/.idea/misc.xml
+++ b/api/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/vet-spring/src/App.jsx
+++ b/vet-spring/src/App.jsx
@@ -6,7 +6,7 @@ import pawssBackgroundImage from "/src/assets/icons/pawss_for_background_spaced_
 
 const App = () => {
   return (
-    <div>
+    <div className="relative min-h-screen">
 
       {/* Paws background globally */}
       <div
@@ -18,8 +18,7 @@ const App = () => {
       <div className="relative px-2 pb-2">
         <CustomToaster reverseOrder={false} />
         <VetClinicRoutes />
-      </div> 
-      
+      </div>
     </div>
   );
 };

--- a/vet-spring/src/App.jsx
+++ b/vet-spring/src/App.jsx
@@ -6,7 +6,9 @@ import pawssBackgroundImage from "/src/assets/icons/pawss_for_background_spaced_
 
 const App = () => {
   return (
+    
     <div className="relative min-h-screen">
+      {/* Above code has to have relative and min-h-screen ; it ensures pawss images cover whole page */}
 
       {/* Paws background globally */}
       <div
@@ -14,7 +16,7 @@ const App = () => {
         style={{ backgroundImage: `url(${pawssBackgroundImage})` }}
       ></div>
 
-      {/* Content sits above paw background */}
+      {/* Content sits above paw background; relative is essential here for that. */}
       <div className="relative px-2 pb-2">
         <CustomToaster reverseOrder={false} />
         <VetClinicRoutes />

--- a/vet-spring/src/App.jsx
+++ b/vet-spring/src/App.jsx
@@ -7,7 +7,7 @@ import pawssBackgroundImage from "/src/assets/icons/pawss_for_background_spaced_
 const App = () => {
   return (
     <div className="relative w-full min-h-screen">
-      
+
       {/* Paws background globally */}
       <div
         className="absolute inset-0 bg-repeat bg-[length:3rem_3rem] sm:bg-[length:3rem_3rem] md:bg-[length:6rem_6rem] lg:bg-[length:9rem_9rem] bg-[center_top_0.1rem] opacity-5 pointer-events-none z-0"
@@ -15,7 +15,7 @@ const App = () => {
       ></div>
 
       {/* Content sits above paw background */}
-      <div className="px-2 pb-2">
+      <div className="relative px-2 pb-2">
         <CustomToaster reverseOrder={false} />
         <VetClinicRoutes />
       </div>

--- a/vet-spring/src/App.jsx
+++ b/vet-spring/src/App.jsx
@@ -6,7 +6,7 @@ import pawssBackgroundImage from "/src/assets/icons/pawss_for_background_spaced_
 
 const App = () => {
   return (
-    <div className="relative w-full min-h-screen">
+    <div>
 
       {/* Paws background globally */}
       <div
@@ -18,7 +18,8 @@ const App = () => {
       <div className="relative px-2 pb-2">
         <CustomToaster reverseOrder={false} />
         <VetClinicRoutes />
-      </div>
+      </div> 
+      
     </div>
   );
 };

--- a/vet-spring/src/App.jsx
+++ b/vet-spring/src/App.jsx
@@ -2,12 +2,23 @@
 import "./App.css";
 import VetClinicRoutes from "./components/VetClinicRoutes";
 import { CustomToaster } from "@/components/uiBase/CustomToaster";
+import pawssBackgroundImage from "/src/assets/icons/pawss_for_background_spaced_out_rotated_1536px.png";
 
 const App = () => {
   return (
-    <div className="px-2 pb-2">
+    <div className="relative w-full min-h-screen">
+      
+      {/* Paws background globally */}
+      <div
+        className="absolute inset-0 bg-repeat bg-[length:3rem_3rem] sm:bg-[length:3rem_3rem] md:bg-[length:6rem_6rem] lg:bg-[length:9rem_9rem] bg-[center_top_0.1rem] opacity-5 pointer-events-none z-0"
+        style={{ backgroundImage: `url(${pawssBackgroundImage})` }}
+      ></div>
+
+      {/* Content sits above paw background */}
+      <div className="px-2 pb-2">
         <CustomToaster reverseOrder={false} />
         <VetClinicRoutes />
+      </div>
     </div>
   );
 };

--- a/vet-spring/src/components/admin/AdminPage.jsx
+++ b/vet-spring/src/components/admin/AdminPage.jsx
@@ -31,7 +31,7 @@ const AdminPage = ({ initialList }) => {
       }}
     >
       <div>
-        <div className="admin-page relative flex flex-col items-center gap-2 sm:px-4 md:px-6 lg:px-8 max-w-[1500px] mx-auto">
+        <div className="admin-page flex flex-col items-center gap-2 sm:px-4 md:px-6 lg:px-8 max-w-[1500px] mx-auto">
           <h1 className="text-black lg:text-2xl md:text-xl sm:text-lg text-base font-semibold text-center py-8 mb-4 mt-12">
             Admin Panel
           </h1>

--- a/vet-spring/src/components/admin/AdminPage.jsx
+++ b/vet-spring/src/components/admin/AdminPage.jsx
@@ -62,4 +62,5 @@ const AdminPage = ({ initialList }) => {
 
 export default AdminPage;
 
-//bg-[length:6rem_6rem]
+////bg-[length:6rem_6rem]
+//

--- a/vet-spring/src/components/admin/AdminPage.jsx
+++ b/vet-spring/src/components/admin/AdminPage.jsx
@@ -4,8 +4,6 @@ import ModalContext from '../../utils/helpers/modalContext';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
-import pawssBackgroundImage from '/src/assets/icons/pawss_for_background_spaced_out_rotated_1536px.png';
-
 const AdminPage = ({ initialList }) => {
   const [activeList, setActiveList] = useState(initialList || '');
   const [deleteModalID, setDeleteModalID] = useState('');
@@ -32,16 +30,8 @@ const AdminPage = ({ initialList }) => {
         setEditPasswordModalID
       }}
     >
-      {/* MAIN WRAPPER BELOW NAVBAR */}
-      <div className="relative w-full min-h-screen">
-        {/* Paws background inside wrapper, starts after navbar naturally */}
-        <div
-          className="absolute inset-0 bg-repeat bg-[length:3rem_3rem] sm:bg-[length:3rem_3rem] md:bg-[length:6rem_6rem] lg:bg-[length:9rem_9rem] bg-center opacity-5 pointer-events-none z-0"
-          style={{ backgroundImage: `url(${pawssBackgroundImage})` }}
-        ></div>
-
-        {/* Main Content - z-10 so it appears above background */}
-        <div className="admin-page relative z-10 flex flex-col items-center gap-2 sm:px-4 md:px-6 lg:px-8 max-w-[1500px] mx-auto">
+      <div>
+        <div className="admin-page relative flex flex-col items-center gap-2 sm:px-4 md:px-6 lg:px-8 max-w-[1500px] mx-auto">
           <h1 className="text-black lg:text-2xl md:text-xl sm:text-lg text-base font-semibold text-center py-8 mb-4 mt-12">
             Admin Panel
           </h1>

--- a/vet-spring/src/pages/designtest/BandytiDesign.jsx
+++ b/vet-spring/src/pages/designtest/BandytiDesign.jsx
@@ -78,3 +78,5 @@ export default BandytiDesign;
 //Comment for initial commit for KOM-124 18:22 03/04/2025
 
 //Comment for commit for KOM-124 13:28 11/04/2025 before merge main
+
+//Comment for initial commit for KOM-136_alt2 16:41 27/04/2025

--- a/vet-spring/src/pages/designtest/BandytiDesignAppjsxMain27-04-2025.jsx
+++ b/vet-spring/src/pages/designtest/BandytiDesignAppjsxMain27-04-2025.jsx
@@ -1,0 +1,15 @@
+
+// import "./App.css";
+// import VetClinicRoutes from "./components/VetClinicRoutes";
+// import { CustomToaster } from "@/components/uiBase/CustomToaster";
+
+// const App = () => {
+//   return (
+//     <div className="px-2 pb-2">
+//         <CustomToaster reverseOrder={false} />
+//         <VetClinicRoutes />
+//     </div>
+//   );
+// };
+
+// export default App;

--- a/vet-spring/src/pages/pets/PetList.jsx
+++ b/vet-spring/src/pages/pets/PetList.jsx
@@ -119,7 +119,6 @@ export const PetList = () => {
             <Error error={error} isHidden={!error} />
           </div>
         </ThemeContext.Provider>
-      </div>
     </>
   );
 };

--- a/vet-spring/src/pages/pets/PetList.jsx
+++ b/vet-spring/src/pages/pets/PetList.jsx
@@ -6,9 +6,6 @@ import ThemeContext from "../../utils/helpers/themeContext.js";
 import AddPetButton from "./AddPetButton.jsx";
 import { useList } from "../../context/ListContext.jsx";
 
-import pawssBackgroundImage from '/src/assets/icons/pawss_for_background_spaced_out_rotated_1536px.png';
-
-
 export const PetList = () => {
   const { account } = useAuth();
   const { iat } = account || "";
@@ -46,14 +43,6 @@ export const PetList = () => {
 
   return (
     <>
-      {/* MAIN WRAPPER BELOW NAVBAR */}
-      <div className="relative w-full min-h-screen">
-        {/* Paws background inside wrapper, starts after navbar naturally */}
-        <div
-          className="absolute inset-0 bg-repeat bg-[length:3rem_3rem] sm:bg-[length:3rem_3rem] md:bg-[length:6rem_6rem] lg:bg-[length:9rem_9rem] bg-center opacity-5 pointer-events-none z-0"
-          style={{ backgroundImage: `url(${pawssBackgroundImage})` }}
-        ></div>
-
         {/* Top Section - Future Image & Text */}
         <main className="flex flex-col sm:flex-row items-center justify-center gap-4 py-22 z-10">
           {/* Text Section */}

--- a/vet-spring/src/pages/profile/Profile.jsx
+++ b/vet-spring/src/pages/profile/Profile.jsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import api from "../../utils/api";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
-import pawssBackgroundImage from '/src/assets/icons/pawss_for_background_spaced_out_rotated_1536px.png';
+
 export const Profile = () => {
   const [data, setData] = useState();
   const [error, setError] = useState(null);
@@ -103,11 +103,8 @@ export const Profile = () => {
   };
 
   return (
-    <div className="flex justify-center mt-10 relative w-full">
-      <div
-            className="absolute min-h-screen inset-0 bg-repeat bg-[length:3rem_3rem] sm:bg-[length:3rem_3rem] md:bg-[length:6rem_6rem] lg:bg-[length:9rem_9rem] bg-center opacity-5 pointer-events-none z-0"
-            style={{ backgroundImage: `url(${pawssBackgroundImage})` }}
-          ></div>
+    <div className="flex justify-center mt-10">
+
       <div className="bg-[#97a0f1] rounded-box gap-10 flex flex-col p-5 z-2">
         <h2>
           Email:{" "}


### PR DESCRIPTION
THIRD ATTEPMT KOM-136_alt2 is the correct one.  KOM-136 and KOM-136_alt should be left in "closed and unmerged" section of pull requests.

Using pawss_for_background_spaced_out_rotated_1536px.png + the tailwind code: bg-repeat in order to implement pawss images on all Pages of the Website. Code is inserted inside App.jsx for this to happen.

Removed from AdminPage.jsx ; Profile.jsx ; and PetList.jsx the code that was previously responsible for positioning the pawss images. As there is a better strategy - using App.jsx to cover all pages. Less code this way, more uniform design and measurements. Code removed is the following below. As well as such code as relative ; w-full ; min-h-screen; z-10 since it is already present inside the App.jsx .

Code mostly responsible for the background addition:

      {/* Paws background globally */}
      <div
        className="absolute inset-0 bg-repeat bg-[length:3rem_3rem] sm:bg-[length:3rem_3rem] md:bg-[length:6rem_6rem] lg:bg-[length:9rem_9rem] bg-[center_top_0.1rem] opacity-5 pointer-events-none z-0"
        style={{ backgroundImage: `url(${pawssBackgroundImage})` }}
      ></div>
      
Other additions are explained in App.jsx with comments.